### PR TITLE
deps: Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": []
+      },
+      "locked": {
+        "lastModified": 1750315135,
+        "narHash": "sha256-SnX5IW9zTVYhKKX/Q8zk0VJV8/ch+UIo4IahxqAJLA8=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b4c4ecfacdb343b8b5d48d90692db461a32d3d8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750215678,
+        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
     
     fenix = {
       url = "github:nix-community/fenix";
@@ -46,8 +43,14 @@
         # Override crane to use nightly toolchain
         cranelibNightly = craneLib.overrideToolchain rustNightly;
         
+        # Get package info from the actual package Cargo.toml
+        crateInfo = craneLib.crateNameFromCargoToml {
+          cargoToml = ./rust-docs-mcp/Cargo.toml;
+        };
+        
         # Shared build args for all crane builds
         commonArgs = {
+          inherit (crateInfo) pname version;
           src = craneLib.cleanCargoSource (craneLib.path ./.);
           buildInputs = with pkgs; [
             openssl

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,109 @@
+{
+  description = "rust-docs-mcp - Rust documentation MCP server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-analyzer-src.follows = "";
+    };
+  };
+
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+
+      perSystem = {
+        system,
+        config,
+        inputs',
+        pkgs,
+        ...
+      }: let
+        toolchain = inputs'.fenix.packages.latest.toolchain;
+        rustNightly = inputs'.fenix.packages.complete.withComponents [
+          "cargo"
+          "clippy"
+          "rust-src"
+          "rustc"
+          "rustfmt"
+        ];
+        
+        craneLib = inputs.crane.mkLib pkgs;
+        
+        # Override crane to use nightly toolchain
+        cranelibNightly = craneLib.overrideToolchain rustNightly;
+        
+        # Shared build args for all crane builds
+        commonArgs = {
+          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          buildInputs = with pkgs; [
+            openssl
+            pkg-config
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.SystemConfiguration
+          ];
+          
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+        };
+        
+        # Build dependencies only
+        cargoArtifacts = cranelibNightly.buildDepsOnly commonArgs;
+        
+        # Build the actual crate
+        rust-docs-mcp = cranelibNightly.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+        });
+      in {
+        packages = {
+          inherit rust-docs-mcp;
+          default = rust-docs-mcp;
+        };
+        
+        devShells.default = cranelibNightly.devShell {
+          checks = self.checks.${system};
+          packages = with pkgs; [
+            rustNightly
+            rust-analyzer
+            cargo-watch
+            cargo-expand
+          ];
+        };
+        
+        # Optional: Add checks
+        checks = {
+          inherit rust-docs-mcp;
+          
+          rust-docs-mcp-clippy = cranelibNightly.cargoClippy (commonArgs // {
+            inherit cargoArtifacts;
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+          
+          rust-docs-mcp-fmt = cranelibNightly.cargoFmt {
+            inherit (commonArgs) src;
+          };
+          
+          rust-docs-mcp-nextest = cranelibNightly.cargoNextest (commonArgs // {
+            inherit cargoArtifacts;
+            partitions = 1;
+            partitionType = "count";
+          });
+        };
+      };
+    };
+}


### PR DESCRIPTION
- Set up flake.nix using crane for Rust build management
- Configure fenix for nightly Rust toolchain support
- Add necessary build inputs for OpenSSL and platform-specific deps
- Include dev shell with rust-analyzer and cargo tools
- Add checks for clippy, formatting, and nextest

🤖 Generated with [Claude Code](https://claude.ai/code)