### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/snowmead/rust-docs-mcp/security/code-scanning/1](https://github.com/snowmead/rust-docs-mcp/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents, we can set `contents: read` at the root level of the workflow. This will apply the least privilege principle and ensure that the workflow does not inadvertently gain write access.

The changes will be made to the `.github/workflows/rust.yml` file. Specifically:
- Add a `permissions` block at the root level of the workflow, immediately after the `name` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
