### PR TITLE
Make version optional for local path caching with auto-detection

### DIFF
--- a/rust-docs-mcp/src/cache/storage.rs
+++ b/rust-docs-mcp/src/cache/storage.rs
@@ -307,7 +307,9 @@ impl CacheStorage {
             .join("rust-docs-mcp-backup")
             .join(format!(
                 "{name}-{version}-{}-{}",
-                chrono::Utc::now().timestamp_nanos_opt().unwrap_or_else(|| chrono::Utc::now().timestamp_micros()),
+                chrono::Utc::now()
+                    .timestamp_nanos_opt()
+                    .unwrap_or_else(|| chrono::Utc::now().timestamp_micros()),
                 std::process::id()
             ));
 

--- a/rust-docs-mcp/src/cache/tools.rs
+++ b/rust-docs-mcp/src/cache/tools.rs
@@ -53,8 +53,10 @@ pub struct CacheCrateFromGitHubParams {
 pub struct CacheCrateFromLocalParams {
     #[schemars(description = "The name of the crate")]
     pub crate_name: String,
-    #[schemars(description = "The version to use for caching (e.g., '0.1.0')")]
-    pub version: String,
+    #[schemars(
+        description = "Optional version to use for caching. If not provided, the version from the local crate's Cargo.toml will be used. If provided, it will be validated against the actual version."
+    )]
+    pub version: Option<String>,
     #[schemars(
         description = "Local file system path. Supports absolute paths (/path), home paths (~/path), and relative paths (./path, ../path)"
     )]

--- a/rust-docs-mcp/src/cache/transaction.rs
+++ b/rust-docs-mcp/src/cache/transaction.rs
@@ -63,7 +63,7 @@ impl<'a> CacheTransaction<'a> {
                     backup_path.display()
                 );
             }
-            
+
             self.storage
                 .restore_crate_from_backup(&self.crate_name, &self.version, &backup_path)
                 .context("Failed to restore from backup")?;

--- a/rust-docs-mcp/src/cache/utils.rs
+++ b/rust-docs-mcp/src/cache/utils.rs
@@ -3,7 +3,7 @@
 //! This module contains shared utilities used across the cache implementation,
 //! including file operations, error handling, and response formatting.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::fs;
 use std::path::Path;
 
@@ -15,13 +15,15 @@ pub fn copy_directory_contents(src: &Path, dest: &Path) -> Result<()> {
     if !src.exists() {
         bail!("Source directory does not exist: {}", src.display());
     }
-    
+
     if !dest.exists() {
         fs::create_dir_all(dest)
             .with_context(|| format!("Failed to create directory: {}", dest.display()))?;
     }
 
-    for entry in fs::read_dir(src).with_context(|| format!("Failed to read directory: {}", src.display()))? {
+    for entry in
+        fs::read_dir(src).with_context(|| format!("Failed to read directory: {}", src.display()))?
+    {
         let entry = entry?;
         let path = entry.path();
         let name = entry.file_name();


### PR DESCRIPTION
- Made version parameter optional in CacheCrateFromLocalParams
- Added WorkspaceHandler::get_package_version() to extract version from Cargo.toml
- Implemented auto-detection of crate version when not provided
- Added validation to ensure provided versions match the actual crate version

🤖 Generated with [Claude Code](https://claude.ai/code)