### PR TITLE
feat: Add Prometheus metrics and /healthz endpoint

### DIFF
--- a/rust-docs-mcp/Cargo.toml
+++ b/rust-docs-mcp/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.0", features = ["derive", "env"] }
 dirs = "6.0"
 flate2 = "1.0"
+fs2 = "0.4"
 futures = "0.3"
 git2 = "0.20"
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/rust-docs-mcp/src/health_tests.rs
+++ b/rust-docs-mcp/src/health_tests.rs
@@ -1,0 +1,145 @@
+#[cfg(test)]
+mod tests {
+    use super::super::health::*;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_health_status_new() {
+        let health = HealthStatus::new();
+        assert!(health.checks.is_empty());
+        assert!(health.metrics.is_empty());
+    }
+
+    #[test]
+    fn test_health_status_clone() {
+        let health = HealthStatus::new();
+        let cloned = health.clone();
+        assert_eq!(health.checks.len(), cloned.checks.len());
+        assert_eq!(health.metrics.len(), cloned.metrics.len());
+    }
+
+    #[test]
+    fn test_is_healthy() {
+        let mut health = HealthStatus::new();
+        
+        // Should be healthy when no checks
+        assert!(health.is_healthy());
+        
+        // Add healthy check
+        let mut healthy_check = HealthCheck {
+            status: "healthy".to_string(),
+            details: HashMap::new(),
+        };
+        healthy_check.details.insert("test".to_string(), serde_json::Value::Bool(true));
+        health.checks.insert("test_check".to_string(), healthy_check);
+        assert!(health.is_healthy());
+        
+        // Add unhealthy check
+        let unhealthy_check = HealthCheck {
+            status: "unhealthy".to_string(),
+            details: HashMap::new(),
+        };
+        health.checks.insert("failing_check".to_string(), unhealthy_check);
+        assert!(!health.is_healthy());
+    }
+
+    #[test]
+    fn test_set_cache_metrics() {
+        let mut health = HealthStatus::new();
+        health.set_cache_metrics(10, 1024);
+        
+        assert_eq!(
+            health.metrics.get("cache_entries").unwrap(),
+            &serde_json::Value::Number(serde_json::Number::from(10))
+        );
+        assert_eq!(
+            health.metrics.get("cache_size_mb").unwrap(),
+            &serde_json::Value::Number(serde_json::Number::from(1024))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_metrics() {
+        let mut health = HealthStatus::new();
+        health.update_metrics().await.unwrap();
+        
+        // Check uptime is set
+        assert!(health.metrics.contains_key("uptime_seconds"));
+        let uptime = health.metrics.get("uptime_seconds").unwrap();
+        assert!(uptime.is_number());
+        
+        // Check default cache metrics
+        assert_eq!(
+            health.metrics.get("cache_entries").unwrap(),
+            &serde_json::Value::Number(serde_json::Number::from(0))
+        );
+        assert_eq!(
+            health.metrics.get("cache_size_mb").unwrap(),
+            &serde_json::Value::Number(serde_json::Number::from(0))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_directory_check_with_temp_dir() {
+        let mut health = HealthStatus::new();
+        let temp_dir = TempDir::new().unwrap();
+        
+        health.update_cache_directory_check(Some(temp_dir.path())).await.unwrap();
+        
+        let check = health.checks.get("cache_directory").unwrap();
+        assert_eq!(check.status, "healthy");
+        assert_eq!(check.details.get("writable").unwrap(), &serde_json::Value::Bool(true));
+        assert!(check.details.contains_key("available_space_mb"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_directory_check_nonexistent() {
+        let mut health = HealthStatus::new();
+        let temp_dir = TempDir::new().unwrap();
+        let nonexistent = temp_dir.path().join("nonexistent");
+        
+        health.update_cache_directory_check(Some(&nonexistent)).await.unwrap();
+        
+        let check = health.checks.get("cache_directory").unwrap();
+        // Should create the directory
+        assert_eq!(check.status, "healthy");
+        assert_eq!(check.details.get("writable").unwrap(), &serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn test_get_available_space() {
+        let temp_dir = TempDir::new().unwrap();
+        let space = super::super::health::get_available_space(temp_dir.path()).unwrap();
+        // Should return a value >= 0
+        assert!(space >= 0);
+    }
+
+    #[tokio::test]
+    async fn test_network_check() {
+        let mut health = HealthStatus::new();
+        
+        // This test might fail if no network is available
+        let result = health.update_network_check().await;
+        assert!(result.is_ok());
+        
+        let check = health.checks.get("network").unwrap();
+        // Status should be either healthy or degraded
+        assert!(check.status == "healthy" || check.status == "degraded");
+        assert!(check.details.contains_key("crates_io_reachable"));
+    }
+
+    #[tokio::test]
+    async fn test_rust_toolchain_check() {
+        let mut health = HealthStatus::new();
+        
+        health.update_rust_toolchain_check().await.unwrap();
+        
+        let check = health.checks.get("rust_toolchain").unwrap();
+        // Should have status
+        assert!(!check.status.is_empty());
+        assert!(check.details.contains_key("nightly_available"));
+        assert!(check.details.contains_key("rustdoc_functional"));
+    }
+}

--- a/rust-docs-mcp/src/metrics.rs
+++ b/rust-docs-mcp/src/metrics.rs
@@ -191,3 +191,7 @@ async fn health_check(
         Err(StatusCode::SERVICE_UNAVAILABLE)
     }
 }
+
+#[cfg(test)]
+#[path = "metrics_tests.rs"]
+mod tests;

--- a/rust-docs-mcp/src/metrics_tests.rs
+++ b/rust-docs-mcp/src/metrics_tests.rs
@@ -1,0 +1,122 @@
+#[cfg(test)]
+mod tests {
+    use super::super::metrics::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_metrics_server_new() {
+        let metrics = MetricsServer::new();
+        assert!(metrics.is_ok());
+    }
+
+    #[test]
+    fn test_cache_metrics() {
+        let metrics = MetricsServer::new().unwrap();
+        
+        // Record cache hits
+        metrics.record_cache_hit("test_crate");
+        metrics.record_cache_hit("test_crate");
+        metrics.record_cache_hit("another_crate");
+        
+        // Record cache misses
+        metrics.record_cache_miss("test_crate");
+        metrics.record_cache_miss("missing_crate");
+        
+        // Set cache size and entries
+        metrics.set_cache_size_bytes(1024.0 * 1024.0 * 100.0); // 100MB
+        metrics.set_cache_entries_total(5.0);
+    }
+
+    #[test]
+    fn test_query_metrics() {
+        let metrics = MetricsServer::new().unwrap();
+        
+        // Record query duration
+        metrics.record_query_duration("cache", "crate_from_cratesio", Duration::from_millis(150));
+        metrics.record_query_duration("docs", "search_items", Duration::from_millis(50));
+        metrics.record_query_duration("deps", "get_dependencies", Duration::from_millis(75));
+        
+        // Record query errors
+        metrics.record_query_error("network_error");
+        metrics.record_query_error("parse_error");
+    }
+
+    #[test]
+    fn test_system_metrics() {
+        let metrics = MetricsServer::new().unwrap();
+        
+        // Set system metrics
+        metrics.set_memory_usage_bytes(1024.0 * 1024.0 * 512.0); // 512MB
+        metrics.set_disk_usage_bytes(1024.0 * 1024.0 * 1024.0 * 2.0); // 2GB
+        metrics.set_uptime_seconds(3600.0); // 1 hour
+    }
+
+    #[tokio::test]
+    async fn test_health_status_access() {
+        let metrics = MetricsServer::new().unwrap();
+        let health_status = metrics.get_health_status();
+        
+        {
+            let mut health = health_status.write().await;
+            health.set_cache_metrics(10, 100);
+        }
+        
+        {
+            let health = health_status.read().await;
+            assert_eq!(
+                health.metrics.get("cache_entries").unwrap(),
+                &serde_json::Value::Number(serde_json::Number::from(10))
+            );
+        }
+    }
+
+    #[test]
+    fn test_metrics_server_clone() {
+        let metrics = MetricsServer::new().unwrap();
+        let cloned = metrics.clone();
+        
+        // Both should point to the same metrics
+        metrics.record_cache_hit("test");
+        cloned.record_cache_hit("test");
+        
+        // Should work without panicking
+        metrics.set_cache_size_bytes(1000.0);
+        cloned.set_cache_size_bytes(2000.0);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_server_concurrent_access() {
+        use std::sync::Arc;
+        use tokio::task;
+        
+        let metrics = Arc::new(MetricsServer::new().unwrap());
+        let mut handles = vec![];
+        
+        // Spawn multiple tasks that update metrics concurrently
+        for i in 0..10 {
+            let metrics_clone = metrics.clone();
+            let handle = task::spawn(async move {
+                metrics_clone.record_cache_hit(&format!("crate_{}", i));
+                metrics_clone.record_query_duration(
+                    "test",
+                    &format!("op_{}", i),
+                    Duration::from_millis(i as u64 * 10),
+                );
+                
+                if i % 2 == 0 {
+                    metrics_clone.set_cache_entries_total(i as f64);
+                }
+            });
+            handles.push(handle);
+        }
+        
+        // Wait for all tasks to complete
+        for handle in handles {
+            handle.await.unwrap();
+        }
+        
+        // Verify metrics were updated (no specific values checked due to race conditions)
+        let health = metrics.get_health_status().read().await;
+        assert!(health.metrics.contains_key("cache_entries"));
+    }
+}

--- a/rust-docs-mcp/src/service.rs
+++ b/rust-docs-mcp/src/service.rs
@@ -34,7 +34,7 @@ pub struct RustDocsService {
 #[tool(tool_box)]
 impl RustDocsService {
     pub fn new(cache_dir: Option<PathBuf>, metrics: Option<Arc<MetricsServer>>) -> Result<Self> {
-        let cache = Arc::new(Mutex::new(CrateCache::new(cache_dir)?));
+        let cache = Arc::new(Mutex::new(CrateCache::new_with_metrics(cache_dir, metrics.clone())?));
 
         Ok(Self {
             cache_tools: CacheTools::new(cache.clone()),
@@ -73,7 +73,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: CacheCrateFromGitHubParams,
     ) -> String {
-        self.cache_tools.cache_crate_from_github(params).await
+        let start = Instant::now();
+        let result = self.cache_tools.cache_crate_from_github(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("cache", "crate_from_github", duration);
+        }
+        
+        result
     }
 
     #[tool(
@@ -83,7 +91,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: CacheCrateFromLocalParams,
     ) -> String {
-        self.cache_tools.cache_crate_from_local(params).await
+        let start = Instant::now();
+        let result = self.cache_tools.cache_crate_from_local(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("cache", "crate_from_local", duration);
+        }
+        
+        result
     }
 
     #[tool(
@@ -98,14 +114,30 @@ impl RustDocsService {
         #[schemars(description = "The version of the crate")]
         version: String,
     ) -> String {
-        self.cache_tools.remove_crate(crate_name, version).await
+        let start = Instant::now();
+        let result = self.cache_tools.remove_crate(crate_name, version).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("cache", "remove_crate", duration);
+        }
+        
+        result
     }
 
     #[tool(
         description = "List all locally cached crates with their versions and sizes. Use to see what crates are available offline and how much disk space they use. Shows cache metadata including when each crate was cached."
     )]
     pub async fn list_cached_crates(&self) -> String {
-        self.cache_tools.list_cached_crates().await
+        let start = Instant::now();
+        let result = self.cache_tools.list_cached_crates().await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("cache", "list_cached_crates", duration);
+        }
+        
+        result
     }
 
     #[tool(
@@ -117,7 +149,15 @@ impl RustDocsService {
         #[schemars(description = "The name of the crate")]
         crate_name: String,
     ) -> String {
-        self.cache_tools.list_crate_versions(crate_name).await
+        let start = Instant::now();
+        let result = self.cache_tools.list_crate_versions(crate_name).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("cache", "list_crate_versions", duration);
+        }
+        
+        result
     }
 
     #[tool(
@@ -127,7 +167,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: crate::cache::tools::GetCratesMetadataParams,
     ) -> String {
-        self.cache_tools.get_crates_metadata(params).await
+        let start = Instant::now();
+        let result = self.cache_tools.get_crates_metadata(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("cache", "get_crates_metadata", duration);
+        }
+        
+        result
     }
 
     // Docs tools
@@ -138,7 +186,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: crate::docs::tools::ListItemsParams,
     ) -> String {
-        self.docs_tools.list_crate_items(params).await
+        let start = Instant::now();
+        let result = self.docs_tools.list_crate_items(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("docs", "list_crate_items", duration);
+        }
+        
+        result
     }
 
     #[tool(
@@ -184,7 +240,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: crate::docs::tools::GetItemDetailsParams,
     ) -> String {
-        self.docs_tools.get_item_details(params).await
+        let start = Instant::now();
+        let result = self.docs_tools.get_item_details(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("docs", "get_item_details", duration);
+        }
+        
+        result
     }
 
     #[tool(
@@ -194,7 +258,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: crate::docs::tools::GetItemDocsParams,
     ) -> String {
-        self.docs_tools.get_item_docs(params).await
+        let start = Instant::now();
+        let result = self.docs_tools.get_item_docs(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("docs", "get_item_docs", duration);
+        }
+        
+        result
     }
 
     #[tool(
@@ -204,7 +276,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: crate::docs::tools::GetItemSourceParams,
     ) -> String {
-        self.docs_tools.get_item_source(params).await
+        let start = Instant::now();
+        let result = self.docs_tools.get_item_source(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("docs", "get_item_source", duration);
+        }
+        
+        result
     }
 
     // Deps tools
@@ -215,7 +295,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: crate::deps::tools::GetDependenciesParams,
     ) -> String {
-        self.deps_tools.get_dependencies(params).await
+        let start = Instant::now();
+        let result = self.deps_tools.get_dependencies(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("deps", "get_dependencies", duration);
+        }
+        
+        result
     }
 
     // Analysis tools
@@ -226,7 +314,15 @@ impl RustDocsService {
         &self,
         #[tool(aggr)] params: crate::analysis::tools::AnalyzeCrateStructureParams,
     ) -> String {
-        self.analysis_tools.structure(params).await
+        let start = Instant::now();
+        let result = self.analysis_tools.structure(params).await;
+        
+        if let Some(metrics) = &self.metrics {
+            let duration = start.elapsed();
+            metrics.record_query_duration("analysis", "structure", duration);
+        }
+        
+        result
     }
 }
 
@@ -249,3 +345,7 @@ impl ServerHandler for RustDocsService {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "service_metrics_tests.rs"]
+mod tests;

--- a/rust-docs-mcp/src/service_metrics_tests.rs
+++ b/rust-docs-mcp/src/service_metrics_tests.rs
@@ -1,0 +1,123 @@
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_service_with_metrics() {
+        let temp_dir = TempDir::new().unwrap();
+        let metrics = Arc::new(metrics::MetricsServer::new().unwrap());
+        
+        let service = RustDocsService::new(
+            Some(temp_dir.path().to_path_buf()),
+            Some(metrics.clone())
+        ).unwrap();
+        
+        // Verify metrics were passed correctly
+        assert!(service.metrics.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_query_duration_metrics() {
+        let temp_dir = TempDir::new().unwrap();
+        let metrics = Arc::new(metrics::MetricsServer::new().unwrap());
+        
+        let service = RustDocsService::new(
+            Some(temp_dir.path().to_path_buf()),
+            Some(metrics.clone())
+        ).unwrap();
+        
+        // Call a tool that has metrics instrumentation
+        let params = cache::tools::CacheCrateFromCratesIOParams {
+            crate_name: "nonexistent-crate-for-testing".to_string(),
+            version: "0.1.0".to_string(),
+            members: None,
+            update: None,
+        };
+        
+        // This will fail but should still record metrics
+        let _ = service.cache_crate_from_cratesio(params).await;
+        
+        // Metrics should have been recorded (can't check exact values due to internal state)
+        // Just verify it doesn't panic
+    }
+
+    #[tokio::test]
+    async fn test_cache_metrics_update() {
+        let temp_dir = TempDir::new().unwrap();
+        let metrics = Arc::new(metrics::MetricsServer::new().unwrap());
+        
+        // Create a cache with metrics
+        let cache = cache::CrateCache::new_with_metrics(
+            Some(temp_dir.path().to_path_buf()),
+            Some(metrics.clone())
+        ).unwrap();
+        
+        // Update cache metrics
+        cache.update_cache_metrics().await.unwrap();
+        
+        // Verify health status was updated
+        let health = metrics.get_health_status().read().await;
+        assert!(health.metrics.contains_key("cache_entries"));
+        assert!(health.metrics.contains_key("cache_size_mb"));
+    }
+
+    #[tokio::test]
+    async fn test_service_without_metrics() {
+        let temp_dir = TempDir::new().unwrap();
+        
+        let service = RustDocsService::new(
+            Some(temp_dir.path().to_path_buf()),
+            None
+        ).unwrap();
+        
+        // Verify service works without metrics
+        assert!(service.metrics.is_none());
+        
+        // Call a tool - should work without metrics
+        let result = service.list_cached_crates().await;
+        assert!(result.contains("cached_crates"));
+    }
+
+    #[tokio::test]
+    async fn test_all_tools_have_metrics() {
+        let temp_dir = TempDir::new().unwrap();
+        let metrics = Arc::new(metrics::MetricsServer::new().unwrap());
+        
+        let service = RustDocsService::new(
+            Some(temp_dir.path().to_path_buf()),
+            Some(metrics.clone())
+        ).unwrap();
+        
+        // Test cache tools
+        let _ = service.list_cached_crates().await;
+        let _ = service.list_crate_versions("test".to_string()).await;
+        
+        // Test search tools (will fail but metrics should be recorded)
+        let search_params = docs::tools::SearchItemsParams {
+            crate_name: "test".to_string(),
+            version: "0.1.0".to_string(),
+            query: "test".to_string(),
+            case_sensitive: None,
+            whole_word: None,
+            limit: None,
+            member: None,
+        };
+        let _ = service.search_items(search_params.clone()).await;
+        
+        let preview_params = docs::tools::SearchItemsPreviewParams {
+            crate_name: search_params.crate_name,
+            version: search_params.version,
+            query: search_params.query,
+            case_sensitive: search_params.case_sensitive,
+            whole_word: search_params.whole_word,
+            limit: search_params.limit,
+            member: search_params.member,
+        };
+        let _ = service.search_items_preview(preview_params).await;
+        
+        // All calls should complete without panicking
+    }
+}


### PR DESCRIPTION
Implement comprehensive observability features including Prometheus metrics for cache performance and query analytics, plus a health check endpoint for monitoring and deployment readiness.

This implementation addresses issue #15 with:

- Prometheus metrics for cache hit rates, query latency, and system health
- HTTP health check endpoint for container orchestration
- Integration with existing MCP stdio transport
- Minimal performance overhead
- Standard metric naming conventions

Generated with [Claude Code](https://claude.ai/code)