### PR TITLE
Change MCP tool parameters to signed integers for JSON Schema

### DIFF
--- a/rust-docs-mcp/src/analysis/tools.rs
+++ b/rust-docs-mcp/src/analysis/tools.rs
@@ -75,7 +75,7 @@ pub struct AnalyzeCrateStructureParams {
     #[schemars(
         description = "The maximum depth of the generated graph relative to the crate's root node, or nodes selected by 'focus_on'"
     )]
-    pub max_depth: Option<usize>,
+    pub max_depth: Option<i64>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
- Update limit, offset, item_id, context_lines from usize/u32 to i64/i32
- Add bounds checking with .max(0) casting to prevent negative values
- Ensures JSON Schema compatibility while maintaining safety
