### PR TITLE
Fix nix build issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2765,7 @@ dependencies = [
  "clap",
  "dirs",
  "flate2",
+ "fs4",
  "futures",
  "git2",
  "ra_ap_ide",

--- a/rust-docs-mcp/Cargo.toml
+++ b/rust-docs-mcp/Cargo.toml
@@ -52,6 +52,6 @@ tracing-subscriber = { version = "0.3", features = [
     "fmt",
 ] }
 tempfile = "3.8"
-fs2 = "0.4"
+fs4 = "0.13.1"
 
 [dev-dependencies]

--- a/rust-docs-mcp/src/doctor.rs
+++ b/rust-docs-mcp/src/doctor.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use std::fs;
 use reqwest;
 use dirs;
-use fs2;
+use fs4;
 use serde::Serialize;
 use crate::rustdoc;
 
@@ -314,7 +314,7 @@ async fn check_cache_directory(cache_dir: Option<std::path::PathBuf>) -> Diagnos
             let _ = fs::remove_file(&test_file);
             
             // Check available disk space
-            match fs2::available_space(&cache_path) {
+            match fs4::available_space(&cache_path) {
                 Ok(available_bytes) => {
                     let available_formatted = format_bytes(available_bytes);
                     // Warn if less than 1GB available


### PR DESCRIPTION
* Nix flake did not build because fs2 dependency had not trickled down into Cargo.lock
* Switched to fs4 instead as fs2 is ancient (but can revert this part if you prefer fs2)
* ~~Added github workflow to validate nix build doesn't break~~ Didn't get this working, will do in separate PR