### PR TITLE
Optimize cache size by cleaning up build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+**/target
 snapshots
 **/*.snap
 cargo-modules/tests/projects/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ With these capabilities, agents can build confidently with any Rust crate — ev
 
 ### Cache Management
 
-- `cache_crate_from_cratesio` - Download and cache a specific crate version from crates.io
+- `cache_crate_from_cratesio` - Download and cache a specific crate version from crates.io for offline use
 - `cache_crate_from_github` - Download and cache from GitHub (specify branch or tag)
 - `cache_crate_from_local` - Cache from a local file system path
 - `remove_crate` - Remove cached crate versions to free disk space
@@ -61,10 +61,9 @@ With these capabilities, agents can build confidently with any Rust crate — ev
 
 ### Documentation Queries
 
-- `search_items_preview` - Lightweight search returning only IDs, names, and types
-- `search_items` - Full search with complete documentation (may hit token limits)
-- `search_items_fuzzy` - Fuzzy search with typo tolerance and semantic similarity
 - `list_crate_items` - Browse all items in a crate with optional filtering
+- `search_items` - Full search with complete documentation (may hit token limits)
+- `search_items_preview` - Lightweight search returning only IDs, names, and types
 - `get_item_details` - Detailed information about specific items (signatures, fields, etc.)
 - `get_item_docs` - Extract just the documentation string for an item
 - `get_item_source` - View source code with configurable context lines
@@ -76,6 +75,10 @@ With these capabilities, agents can build confidently with any Rust crate — ev
 ### Structure Analysis
 
 - `structure` - Generate hierarchical module tree using integrated cargo-modules
+
+### Search
+
+- `search_items_fuzzy` - Fuzzy search with typo tolerance and semantic similarity
 
 ## Configuration
 

--- a/install.sh
+++ b/install.sh
@@ -202,12 +202,12 @@ main() {
       \"mcp__rust-docs__list_crate_items\",
       \"mcp__rust-docs__search_items\",
       \"mcp__rust-docs__search_items_preview\",
-      \"mcp__rust-docs__search_items_fuzzy\",
       \"mcp__rust-docs__get_item_details\",
       \"mcp__rust-docs__get_item_docs\",
       \"mcp__rust-docs__get_item_source\",
       \"mcp__rust-docs__get_dependencies\",
-      \"mcp__rust-docs__structure\"${NC}"
+      \"mcp__rust-docs__structure\",
+      \"mcp__rust-docs__search_items_fuzzy\"${NC}"
             else
                 warn "Failed to add rust-docs-mcp to Claude Code"
                 echo

--- a/rust-docs-mcp/src/cache/utils.rs
+++ b/rust-docs-mcp/src/cache/utils.rs
@@ -30,8 +30,8 @@ pub fn copy_directory_contents(src: &Path, dest: &Path) -> Result<()> {
         let dest_path = dest.join(&name);
 
         if path.is_dir() {
-            // Skip version control directories
-            if name == ".git" || name == ".svn" || name == ".hg" {
+            // Skip version control directories and target directory
+            if name == ".git" || name == ".svn" || name == ".hg" || name == "target" {
                 continue;
             }
             copy_directory_contents(&path, &dest_path)?;

--- a/rust-docs-mcp/src/search/indexer.rs
+++ b/rust-docs-mcp/src/search/indexer.rs
@@ -28,7 +28,7 @@ use rustdoc_types::Crate;
 use std::path::{Path, PathBuf};
 use tantivy::{
     Index, IndexWriter, TantivyDocument, doc,
-    schema::{FAST, Field, STORED, Schema, TEXT},
+    schema::{FAST, Field, STORED, STRING, Schema, TEXT},
 };
 
 /// Tantivy-based search indexer for Rust documentation
@@ -76,14 +76,14 @@ impl SearchIndexer {
         let name_field = schema_builder.add_text_field("name", TEXT | STORED);
         let docs_field = schema_builder.add_text_field("docs", TEXT);
         let path_field = schema_builder.add_text_field("path", TEXT | STORED);
-        let kind_field = schema_builder.add_text_field("kind", TEXT | STORED);
+        let kind_field = schema_builder.add_text_field("kind", STRING | STORED);
 
         // Metadata fields
-        let crate_field = schema_builder.add_text_field("crate", TEXT | STORED);
-        let version_field = schema_builder.add_text_field("version", TEXT | STORED);
+        let crate_field = schema_builder.add_text_field("crate", STRING | STORED);
+        let version_field = schema_builder.add_text_field("version", STRING | STORED);
         let item_id_field = schema_builder.add_u64_field("item_id", FAST | STORED);
         let visibility_field = schema_builder.add_text_field("visibility", TEXT | STORED);
-        let member_field = schema_builder.add_text_field("member", TEXT | STORED);
+        let member_field = schema_builder.add_text_field("member", STRING | STORED);
 
         let schema = schema_builder.build();
 

--- a/rust-docs-mcp/src/search/tools.rs
+++ b/rust-docs-mcp/src/search/tools.rs
@@ -135,6 +135,7 @@ impl SearchTools {
             limit,
             kind_filter: params.kind_filter.clone(),
             crate_filter: Some(params.crate_name.clone()),
+            member_filter: params.member.clone(),
         };
 
         // Perform search


### PR DESCRIPTION
## Summary
- Clean up target/ directories after doc generation to reduce cache size
- Skip target/ when copying crate contents  
- Add member filtering to fuzzy search

## Test plan
- [x] Tested caching crates and verified target/ is removed
- [x] Verified documentation generation still works
- [x] Confirmed search functionality with new member filter

Fixes #29
