### PR TITLE
chore: Upgrade rmcp to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534fd1cd0601e798ac30545ff2b7f4a62c6f14edd4aaed1cc5eb1e85f69f09af"
+checksum = "583d060e99feb3a3683fb48a1e4bf5f8d4a50951f429726f330ee5ff548837f8"
 dependencies = [
  "base64",
  "chrono",
@@ -3032,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba777eb0e5f53a757e36f0e287441da0ab766564ba7201600eeb92a4753022e"
+checksum = "421d8b0ba302f479214889486f9550e63feca3af310f1190efcf6e2016802693"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/rust-docs-mcp/Cargo.toml
+++ b/rust-docs-mcp/Cargo.toml
@@ -16,8 +16,8 @@ categories = ["development-tools", "command-line-utilities"]
 rust-analyzer-modules = { version = "0.1", path = "../cargo-modules" }
 ra_ap_ide = "=0.0.289"
 
-rmcp = { version = "0.7.0", features = ["server", "macros", "transport-io"] }
-rmcp-macros = "0.7.0"
+rmcp = { version = "0.8.0", features = ["server", "macros", "transport-io"] }
+rmcp-macros = "0.8.0"
 
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/rust-docs-mcp/src/analysis/tools.rs
+++ b/rust-docs-mcp/src/analysis/tools.rs
@@ -138,7 +138,7 @@ async fn analyze_with_cargo_modules(
 
         // Analyze the crate using the public API
         let (crate_id, analysis_host, edition) = rust_analyzer_modules::analyze_crate(
-            &manifest_path.parent().unwrap(),
+            manifest_path.parent().unwrap(),
             package.as_deref(),
             config,
         )

--- a/rust-docs-mcp/src/cache/docgen.rs
+++ b/rust-docs-mcp/src/cache/docgen.rs
@@ -62,9 +62,7 @@ impl DocGenerator {
 
         if !source_path.exists() {
             bail!(
-                "Source not found for {}-{}. Download it first.",
-                name,
-                version
+                "Source not found for {name}-{version}. Download it first."
             );
         }
 
@@ -119,9 +117,7 @@ impl DocGenerator {
 
         if !source_path.exists() {
             bail!(
-                "Source not found for {}-{}. Download it first.",
-                name,
-                version
+                "Source not found for {name}-{version}. Download it first."
             );
         }
 
@@ -234,7 +230,7 @@ impl DocGenerator {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to generate dependency metadata: {}", stderr);
+            bail!("Failed to generate dependency metadata: {stderr}");
         }
 
         // Save the raw metadata output
@@ -282,7 +278,7 @@ impl DocGenerator {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to generate dependency metadata: {}", stderr);
+            bail!("Failed to generate dependency metadata: {stderr}");
         }
 
         // Ensure the member directory exists
@@ -308,7 +304,7 @@ impl DocGenerator {
         let deps_path = self.storage.dependencies_path(name, version, None)?;
 
         if !deps_path.exists() {
-            bail!("Dependencies not found for {}-{}", name, version);
+            bail!("Dependencies not found for {name}-{version}");
         }
 
         let json_string = tokio::fs::read_to_string(&deps_path)
@@ -333,13 +329,10 @@ impl DocGenerator {
         if !docs_path.exists() {
             if let Some(member) = member_name {
                 bail!(
-                    "Documentation not found for workspace member {} in {}-{}",
-                    member,
-                    name,
-                    version
+                    "Documentation not found for workspace member {member} in {name}-{version}"
                 );
             } else {
-                bail!("Documentation not found for {}-{}", name, version);
+                bail!("Documentation not found for {name}-{version}");
             }
         }
 

--- a/rust-docs-mcp/src/cache/docgen.rs
+++ b/rust-docs-mcp/src/cache/docgen.rs
@@ -61,9 +61,7 @@ impl DocGenerator {
         }
 
         if !source_path.exists() {
-            bail!(
-                "Source not found for {name}-{version}. Download it first."
-            );
+            bail!("Source not found for {name}-{version}. Download it first.");
         }
 
         tracing::info!("Generating documentation for {}-{}", name, version);
@@ -116,9 +114,7 @@ impl DocGenerator {
         let member_full_path = source_path.join(member_path);
 
         if !source_path.exists() {
-            bail!(
-                "Source not found for {name}-{version}. Download it first."
-            );
+            bail!("Source not found for {name}-{version}. Download it first.");
         }
 
         if !member_full_path.exists() {
@@ -328,9 +324,7 @@ impl DocGenerator {
 
         if !docs_path.exists() {
             if let Some(member) = member_name {
-                bail!(
-                    "Documentation not found for workspace member {member} in {name}-{version}"
-                );
+                bail!("Documentation not found for workspace member {member} in {name}-{version}");
             } else {
                 bail!("Documentation not found for {name}-{version}");
             }

--- a/rust-docs-mcp/src/cache/downloader.rs
+++ b/rust-docs-mcp/src/cache/downloader.rs
@@ -376,7 +376,7 @@ impl CrateDownloader {
         if version != "main" && version != "master" {
             // Validate git reference name to prevent potential issues
             if !Self::is_valid_git_ref(version) {
-                bail!("Invalid git reference name: {}", version);
+                bail!("Invalid git reference name: {version}");
             }
 
             // Try to checkout as a branch first
@@ -401,7 +401,7 @@ impl CrateDownloader {
                     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
                         .with_context(|| format!("Failed to checkout tag: {version}"))?;
                 } else {
-                    bail!("Could not find branch or tag: {}", version);
+                    bail!("Could not find branch or tag: {version}");
                 }
             }
         }

--- a/rust-docs-mcp/src/cache/member_utils.rs
+++ b/rust-docs-mcp/src/cache/member_utils.rs
@@ -29,32 +29,28 @@ pub fn validate_member_path(member_path: &str) -> Result<()> {
     // Reject absolute paths
     if member_path.starts_with('/') || member_path.starts_with('\\') {
         bail!(
-            "Invalid member path '{}': absolute paths not allowed",
-            member_path
+            "Invalid member path '{member_path}': absolute paths not allowed"
         );
     }
 
     // Check for Windows absolute paths (e.g., C:\)
     if member_path.len() > 2 && member_path.chars().nth(1) == Some(':') {
         bail!(
-            "Invalid member path '{}': absolute paths not allowed",
-            member_path
+            "Invalid member path '{member_path}': absolute paths not allowed"
         );
     }
 
     // Reject path traversal
     if member_path.contains("..") {
         bail!(
-            "Invalid member path '{}': path traversal not allowed",
-            member_path
+            "Invalid member path '{member_path}': path traversal not allowed"
         );
     }
 
     // Reject backslashes (Windows paths)
     if member_path.contains('\\') {
         bail!(
-            "Invalid member path '{}': backslashes not allowed",
-            member_path
+            "Invalid member path '{member_path}': backslashes not allowed"
         );
     }
 

--- a/rust-docs-mcp/src/cache/member_utils.rs
+++ b/rust-docs-mcp/src/cache/member_utils.rs
@@ -28,30 +28,22 @@ pub fn validate_member_path(member_path: &str) -> Result<()> {
 
     // Reject absolute paths
     if member_path.starts_with('/') || member_path.starts_with('\\') {
-        bail!(
-            "Invalid member path '{member_path}': absolute paths not allowed"
-        );
+        bail!("Invalid member path '{member_path}': absolute paths not allowed");
     }
 
     // Check for Windows absolute paths (e.g., C:\)
     if member_path.len() > 2 && member_path.chars().nth(1) == Some(':') {
-        bail!(
-            "Invalid member path '{member_path}': absolute paths not allowed"
-        );
+        bail!("Invalid member path '{member_path}': absolute paths not allowed");
     }
 
     // Reject path traversal
     if member_path.contains("..") {
-        bail!(
-            "Invalid member path '{member_path}': path traversal not allowed"
-        );
+        bail!("Invalid member path '{member_path}': path traversal not allowed");
     }
 
     // Reject backslashes (Windows paths)
     if member_path.contains('\\') {
-        bail!(
-            "Invalid member path '{member_path}': backslashes not allowed"
-        );
+        bail!("Invalid member path '{member_path}': backslashes not allowed");
     }
 
     Ok(())

--- a/rust-docs-mcp/src/cache/service.rs
+++ b/rust-docs-mcp/src/cache/service.rs
@@ -116,10 +116,9 @@ impl CrateCache {
             Err(e) if e.to_string().contains("This is a binary-only package") => {
                 // This is a binary-only package, return appropriate error
                 bail!(
-                    "Cannot generate documentation for binary-only package '{}'. \
+                    "Cannot generate documentation for binary-only package '{name}'. \
                     This package contains only binary targets and no library to document. \
-                    rustdoc can only generate documentation for library targets.",
-                    name
+                    rustdoc can only generate documentation for library targets."
                 )
             }
             Err(e) => Err(e),
@@ -351,11 +350,8 @@ impl CrateCache {
 
             if !member_cargo_toml.exists() {
                 bail!(
-                    "Workspace member '{}' not found in {}-{}. \
-                    Make sure the member path is correct.",
-                    member_path,
-                    name,
-                    version
+                    "Workspace member '{member_path}' not found in {name}-{version}. \
+                    Make sure the member path is correct."
                 );
             }
 
@@ -405,7 +401,7 @@ impl CrateCache {
             } = &response
                 && results.is_empty()
             {
-                bail!("Failed to update any workspace members: {:?}", errors);
+                bail!("Failed to update any workspace members: {errors:?}");
             }
 
             return Ok(response);
@@ -755,9 +751,7 @@ impl CrateCache {
                     // Version was provided, validate it matches
                     if provided_version != &actual_version {
                         bail!(
-                            "Version mismatch: provided version '{}' does not match actual version '{}' in Cargo.toml",
-                            provided_version,
-                            actual_version
+                            "Version mismatch: provided version '{provided_version}' does not match actual version '{actual_version}' in Cargo.toml"
                         );
                     }
                     Ok((actual_version, false)) // Version was validated, not auto-detected

--- a/rust-docs-mcp/src/cache/tools.rs
+++ b/rust-docs-mcp/src/cache/tools.rs
@@ -109,10 +109,6 @@ pub struct ListCrateVersionsParams {
     pub crate_name: String,
 }
 
-/// Empty params struct for list_cached_crates tool
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct ListCachedCratesParams {}
-
 #[derive(Debug, Clone)]
 pub struct CacheTools {
     cache: Arc<RwLock<CrateCache>>,

--- a/rust-docs-mcp/src/cache/types.rs
+++ b/rust-docs-mcp/src/cache/types.rs
@@ -13,9 +13,7 @@ use std::str::FromStr;
 fn validate_crate_name(name: &str) -> Result<()> {
     // Check for path traversal attempts
     if name.contains("..") || name.contains("/") || name.contains("\\") {
-        bail!(
-            "Invalid crate name '{name}': contains path separators or traversal sequences"
-        );
+        bail!("Invalid crate name '{name}': contains path separators or traversal sequences");
     }
 
     // Check for absolute paths
@@ -23,9 +21,7 @@ fn validate_crate_name(name: &str) -> Result<()> {
         || name.starts_with('\\')
         || (name.len() > 2 && name.chars().nth(1) == Some(':'))
     {
-        bail!(
-            "Invalid crate name '{name}': appears to be an absolute path"
-        );
+        bail!("Invalid crate name '{name}': appears to be an absolute path");
     }
 
     // Ensure it's a valid crate name pattern (alphanumeric, underscore, dash)

--- a/rust-docs-mcp/src/cache/types.rs
+++ b/rust-docs-mcp/src/cache/types.rs
@@ -14,8 +14,7 @@ fn validate_crate_name(name: &str) -> Result<()> {
     // Check for path traversal attempts
     if name.contains("..") || name.contains("/") || name.contains("\\") {
         bail!(
-            "Invalid crate name '{}': contains path separators or traversal sequences",
-            name
+            "Invalid crate name '{name}': contains path separators or traversal sequences"
         );
     }
 
@@ -25,8 +24,7 @@ fn validate_crate_name(name: &str) -> Result<()> {
         || (name.len() > 2 && name.chars().nth(1) == Some(':'))
     {
         bail!(
-            "Invalid crate name '{}': appears to be an absolute path",
-            name
+            "Invalid crate name '{name}': appears to be an absolute path"
         );
     }
 
@@ -36,8 +34,7 @@ fn validate_crate_name(name: &str) -> Result<()> {
         .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
     {
         bail!(
-            "Invalid crate name '{}': contains invalid characters. Only alphanumeric, underscore, and dash are allowed",
-            name
+            "Invalid crate name '{name}': contains invalid characters. Only alphanumeric, underscore, and dash are allowed"
         );
     }
 

--- a/rust-docs-mcp/src/deps/mod.rs
+++ b/rust-docs-mcp/src/deps/mod.rs
@@ -72,9 +72,7 @@ pub fn process_cargo_metadata(
             p["name"].as_str() == Some(crate_name) && p["version"].as_str() == Some(crate_version)
         })
         .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Package {crate_name}-{crate_version} not found in metadata"
-            )
+            anyhow::anyhow!("Package {crate_name}-{crate_version} not found in metadata")
         })?;
 
     // Extract direct dependencies

--- a/rust-docs-mcp/src/deps/mod.rs
+++ b/rust-docs-mcp/src/deps/mod.rs
@@ -73,9 +73,7 @@ pub fn process_cargo_metadata(
         })
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Package {}-{} not found in metadata",
-                crate_name,
-                crate_version
+                "Package {crate_name}-{crate_version} not found in metadata"
             )
         })?;
 

--- a/rust-docs-mcp/src/rustdoc.rs
+++ b/rust-docs-mcp/src/rustdoc.rs
@@ -24,9 +24,7 @@ pub async fn validate_toolchain() -> Result<()> {
     let toolchains = String::from_utf8_lossy(&output.stdout);
     if !toolchains.contains(REQUIRED_TOOLCHAIN) {
         bail!(
-            "Required toolchain {} is not installed. Please run: rustup toolchain install {}",
-            REQUIRED_TOOLCHAIN,
-            REQUIRED_TOOLCHAIN
+            "Required toolchain {REQUIRED_TOOLCHAIN} is not installed. Please run: rustup toolchain install {REQUIRED_TOOLCHAIN}"
         );
     }
 
@@ -73,7 +71,7 @@ pub async fn test_rustdoc_json() -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("JSON generation failed: {}", stderr);
+        bail!("JSON generation failed: {stderr}");
     }
 
     tracing::debug!("Successfully tested rustdoc JSON generation");
@@ -164,7 +162,7 @@ pub async fn run_cargo_rustdoc_json(source_path: &Path, package: Option<&str>) -
                     bail!("This is a binary-only package");
                 }
 
-                bail!("Failed to generate documentation: {}", stderr_with_lib);
+                bail!("Failed to generate documentation: {stderr_with_lib}");
             }
 
             // Success with --lib
@@ -178,7 +176,7 @@ pub async fn run_cargo_rustdoc_json(source_path: &Path, package: Option<&str>) -
             );
         }
 
-        bail!("Failed to generate documentation: {}", stderr);
+        bail!("Failed to generate documentation: {stderr}");
     }
 
     Ok(())

--- a/rust-docs-mcp/src/search/fuzzy.rs
+++ b/rust-docs-mcp/src/search/fuzzy.rs
@@ -146,8 +146,7 @@ impl FuzzySearcher {
         // Validate query length
         if query.len() > MAX_QUERY_LENGTH {
             return Err(anyhow::anyhow!(
-                "Query too long (max {} characters)",
-                MAX_QUERY_LENGTH
+                "Query too long (max {MAX_QUERY_LENGTH} characters)"
             ));
         }
 

--- a/rust-docs-mcp/src/search/tools.rs
+++ b/rust-docs-mcp/src/search/tools.rs
@@ -115,8 +115,7 @@ impl SearchTools {
         let fuzzy_distance = params.fuzzy_distance.unwrap_or(DEFAULT_FUZZY_DISTANCE);
         if fuzzy_distance > MAX_FUZZY_DISTANCE {
             return Err(anyhow::anyhow!(
-                "Fuzzy distance must be between 0 and {}",
-                MAX_FUZZY_DISTANCE
+                "Fuzzy distance must be between 0 and {MAX_FUZZY_DISTANCE}"
             ));
         }
 
@@ -124,8 +123,7 @@ impl SearchTools {
         let limit = params.limit.unwrap_or(DEFAULT_SEARCH_LIMIT);
         if limit > MAX_SEARCH_LIMIT {
             return Err(anyhow::anyhow!(
-                "Limit must not exceed {}",
-                MAX_SEARCH_LIMIT
+                "Limit must not exceed {MAX_SEARCH_LIMIT}"
             ));
         }
 

--- a/rust-docs-mcp/src/search/tools.rs
+++ b/rust-docs-mcp/src/search/tools.rs
@@ -122,9 +122,7 @@ impl SearchTools {
         // Validate limit
         let limit = params.limit.unwrap_or(DEFAULT_SEARCH_LIMIT);
         if limit > MAX_SEARCH_LIMIT {
-            return Err(anyhow::anyhow!(
-                "Limit must not exceed {MAX_SEARCH_LIMIT}"
-            ));
+            return Err(anyhow::anyhow!("Limit must not exceed {MAX_SEARCH_LIMIT}"));
         }
 
         // Build search options

--- a/rust-docs-mcp/src/service.rs
+++ b/rust-docs-mcp/src/service.rs
@@ -24,8 +24,7 @@ use crate::cache::{
     CrateCache,
     tools::{
         CacheCrateFromCratesIOParams, CacheCrateFromGitHubParams, CacheCrateFromLocalParams,
-        CacheTools, GetCratesMetadataParams, ListCrateVersionsParams,
-        RemoveCrateParams,
+        CacheTools, GetCratesMetadataParams, ListCrateVersionsParams, RemoveCrateParams,
     },
 };
 use crate::deps::tools::{DepsTools, GetDependenciesParams};

--- a/rust-docs-mcp/src/service.rs
+++ b/rust-docs-mcp/src/service.rs
@@ -24,7 +24,7 @@ use crate::cache::{
     CrateCache,
     tools::{
         CacheCrateFromCratesIOParams, CacheCrateFromGitHubParams, CacheCrateFromLocalParams,
-        CacheTools, GetCratesMetadataParams, ListCachedCratesParams, ListCrateVersionsParams,
+        CacheTools, GetCratesMetadataParams, ListCrateVersionsParams,
         RemoveCrateParams,
     },
 };
@@ -127,10 +127,7 @@ impl RustDocsService {
     #[tool(
         description = "List all locally cached crates with their versions and sizes. Use to see what crates are available offline and how much disk space they use. Shows cache metadata including when each crate was cached."
     )]
-    pub async fn list_cached_crates(
-        &self,
-        Parameters(_params): Parameters<ListCachedCratesParams>,
-    ) -> String {
+    pub async fn list_cached_crates(&self) -> String {
         match self.cache_tools.list_cached_crates().await {
             Ok(output) => output.to_json(),
             Err(error) => error.to_json(),

--- a/rust-docs-mcp/src/update.rs
+++ b/rust-docs-mcp/src/update.rs
@@ -56,7 +56,7 @@ pub async fn update_executable(
 
     if !clone_output.status.success() {
         let stderr = String::from_utf8_lossy(&clone_output.stderr);
-        anyhow::bail!("Failed to clone repository: {}", stderr);
+        anyhow::bail!("Failed to clone repository: {stderr}");
     }
 
     // Build the project
@@ -70,7 +70,7 @@ pub async fn update_executable(
 
     if !build_output.status.success() {
         let stderr = String::from_utf8_lossy(&build_output.stderr);
-        anyhow::bail!("Failed to build rust-docs-mcp: {}", stderr);
+        anyhow::bail!("Failed to build rust-docs-mcp: {stderr}");
     }
 
     // Install using the built binary's install command
@@ -89,7 +89,7 @@ pub async fn update_executable(
 
     if !install_output.status.success() {
         let stderr = String::from_utf8_lossy(&install_output.stderr);
-        anyhow::bail!("Failed to install rust-docs-mcp: {}", stderr);
+        anyhow::bail!("Failed to install rust-docs-mcp: {stderr}");
     }
 
     // Handle macOS code signing
@@ -121,7 +121,7 @@ fn check_command_exists(command: &str) -> Result<()> {
         .context("Failed to check command existence")?;
 
     if !output.status.success() {
-        anyhow::bail!("{} is required but not installed", command);
+        anyhow::bail!("{command} is required but not installed");
     }
 
     Ok(())
@@ -149,7 +149,7 @@ fn check_nightly_toolchain() -> Result<()> {
 
         if !install_output.status.success() {
             let stderr = String::from_utf8_lossy(&install_output.stderr);
-            anyhow::bail!("Failed to install Rust nightly toolchain: {}", stderr);
+            anyhow::bail!("Failed to install Rust nightly toolchain: {stderr}");
         }
 
         println!("✅ Rust nightly toolchain installed");

--- a/rust-docs-mcp/tests/integration_tests.rs
+++ b/rust-docs-mcp/tests/integration_tests.rs
@@ -15,7 +15,7 @@ use rust_docs_mcp::cache::outputs::{
 };
 use rust_docs_mcp::cache::tools::{
     CacheCrateFromCratesIOParams, CacheCrateFromGitHubParams, CacheCrateFromLocalParams,
-    CrateMetadataQuery, GetCratesMetadataParams, ListCachedCratesParams, ListCrateVersionsParams,
+    CrateMetadataQuery, GetCratesMetadataParams, ListCrateVersionsParams,
 };
 use rust_docs_mcp::deps::outputs::GetDependenciesOutput;
 use rust_docs_mcp::deps::tools::GetDependenciesParams;
@@ -543,9 +543,7 @@ async fn test_concurrent_caching() -> Result<()> {
     }
 
     // Verify cache consistency - all crates should be present
-    let cached_crates_response = service
-        .list_cached_crates(Parameters(ListCachedCratesParams {}))
-        .await;
+    let cached_crates_response = service.list_cached_crates().await;
     for (name, version) in &test_crates {
         assert!(
             cached_crates_response.contains(name),

--- a/rust-docs-mcp/tests/integration_tests.rs
+++ b/rust-docs-mcp/tests/integration_tests.rs
@@ -42,11 +42,8 @@ const CLIPPY_BRANCH: &str = "master";
 
 // Response validation helpers
 fn parse_cache_response(response: &str) -> Result<CacheCrateOutput> {
-    serde_json::from_str(response).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to parse cache response: {e}\nResponse: {response}"
-        )
-    })
+    serde_json::from_str(response)
+        .map_err(|e| anyhow::anyhow!("Failed to parse cache response: {e}\nResponse: {response}"))
 }
 
 fn is_binary_only_response(response: &str) -> bool {

--- a/rust-docs-mcp/tests/integration_tests.rs
+++ b/rust-docs-mcp/tests/integration_tests.rs
@@ -15,7 +15,7 @@ use rust_docs_mcp::cache::outputs::{
 };
 use rust_docs_mcp::cache::tools::{
     CacheCrateFromCratesIOParams, CacheCrateFromGitHubParams, CacheCrateFromLocalParams,
-    CrateMetadataQuery, GetCratesMetadataParams, ListCrateVersionsParams,
+    CrateMetadataQuery, GetCratesMetadataParams, ListCachedCratesParams, ListCrateVersionsParams,
 };
 use rust_docs_mcp::deps::outputs::GetDependenciesOutput;
 use rust_docs_mcp::deps::tools::GetDependenciesParams;
@@ -543,7 +543,9 @@ async fn test_concurrent_caching() -> Result<()> {
     }
 
     // Verify cache consistency - all crates should be present
-    let cached_crates_response = service.list_cached_crates().await;
+    let cached_crates_response = service
+        .list_cached_crates(Parameters(ListCachedCratesParams {}))
+        .await;
     for (name, version) in &test_crates {
         assert!(
             cached_crates_response.contains(name),

--- a/rust-docs-mcp/tests/integration_tests.rs
+++ b/rust-docs-mcp/tests/integration_tests.rs
@@ -44,9 +44,7 @@ const CLIPPY_BRANCH: &str = "master";
 fn parse_cache_response(response: &str) -> Result<CacheCrateOutput> {
     serde_json::from_str(response).map_err(|e| {
         anyhow::anyhow!(
-            "Failed to parse cache response: {}\nResponse: {}",
-            e,
-            response
+            "Failed to parse cache response: {e}\nResponse: {response}"
         )
     })
 }
@@ -84,7 +82,7 @@ async fn setup_test_crate(service: &RustDocsService) -> Result<()> {
 
     let output = parse_cache_response(&response)?;
     if !output.is_success() {
-        return Err(anyhow::anyhow!("Failed to cache test crate: {:?}", output));
+        return Err(anyhow::anyhow!("Failed to cache test crate: {output:?}"));
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Upgrades rmcp dependencies from 0.7.0 to 0.8.0 and removes unnecessary empty parameter structs enabled by the new automatic schema generation feature.

### Changes
- Updated dependencies: rmcp and rmcp-macros from 0.7.0 → 0.8.0
- Removed ListCachedCratesParams: Empty parameter structs are no longer needed thanks to rmcp 0.8.0's automatic schema generation

### Testing
✅ All 105 tests passing:
cargo check: ✓
cargo test: ✓