### PR TITLE
Use configured toolchain in Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,9 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    
+
     crane.url = "github:ipetkov/crane";
-    
+
     fenix = {
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -29,55 +29,70 @@
         pkgs,
         ...
       }: let
-        toolchain = inputs'.fenix.packages.latest.toolchain;
-        rustNightly = inputs'.fenix.packages.complete.withComponents [
-          "cargo"
-          "clippy"
-          "rust-src"
-          "rustc"
-          "rustfmt"
-        ];
-        
+        # Use rust-toolchain.toml for the exact nightly version
+        rustToolchain = inputs'.fenix.packages.fromToolchainFile {
+          file = ./rust-toolchain.toml;
+          sha256 = "sha256-UAoZcxg3iWtS+2n8TFNfANFt/GmkuOMDf7QAE0fRxeA=";
+        };
+
+        # Nightly toolchain for runtime (used by the binary to fetch docs)
+        rustNightly = rustToolchain;
+
         craneLib = inputs.crane.mkLib pkgs;
-        
+
         # Override crane to use nightly toolchain
         cranelibNightly = craneLib.overrideToolchain rustNightly;
-        
+
         # Get package info from the actual package Cargo.toml
         crateInfo = craneLib.crateNameFromCargoToml {
           cargoToml = ./rust-docs-mcp/Cargo.toml;
         };
-        
+
         # Shared build args for all crane builds
         commonArgs = {
           inherit (crateInfo) pname version;
           src = craneLib.cleanCargoSource (craneLib.path ./.);
-          buildInputs = with pkgs; [
-            openssl
-            pkg-config
-          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            darwin.apple_sdk.frameworks.Security
-            darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
-          
+          buildInputs = with pkgs;
+            [
+              openssl
+              pkg-config
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.Security
+              darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+
           nativeBuildInputs = with pkgs; [
             pkg-config
           ];
         };
-        
+
         # Build dependencies only
         cargoArtifacts = cranelibNightly.buildDepsOnly commonArgs;
-        
+
         # Build the actual crate
-        rust-docs-mcp = cranelibNightly.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-        });
+        rust-docs-mcp-unwrapped = cranelibNightly.buildPackage (commonArgs
+          // {
+            inherit cargoArtifacts;
+            doCheck = false; # Tests require network access
+          });
+
+        # Wrap the binary to include nightly rust in PATH at runtime
+        rust-docs-mcp =
+          pkgs.runCommand "rust-docs-mcp" {
+            nativeBuildInputs = [pkgs.makeWrapper];
+            meta = rust-docs-mcp-unwrapped.meta or {};
+          } ''
+            mkdir -p $out/bin
+            makeWrapper ${rust-docs-mcp-unwrapped}/bin/rust-docs-mcp $out/bin/rust-docs-mcp \
+              --prefix PATH : ${rustNightly}/bin
+          '';
       in {
         packages = {
-          inherit rust-docs-mcp;
+          inherit rust-docs-mcp rust-docs-mcp-unwrapped;
           default = rust-docs-mcp;
         };
-        
+
         devShells.default = cranelibNightly.devShell {
           checks = self.checks.${system};
           packages = with pkgs; [
@@ -87,25 +102,27 @@
             cargo-expand
           ];
         };
-        
+
         # Optional: Add checks
         checks = {
-          inherit rust-docs-mcp;
-          
-          rust-docs-mcp-clippy = cranelibNightly.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-          });
-          
+          rust-docs-mcp = rust-docs-mcp-unwrapped;
+
+          rust-docs-mcp-clippy = cranelibNightly.cargoClippy (commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            });
+
           rust-docs-mcp-fmt = cranelibNightly.cargoFmt {
             inherit (commonArgs) src;
           };
-          
-          rust-docs-mcp-nextest = cranelibNightly.cargoNextest (commonArgs // {
-            inherit cargoArtifacts;
-            partitions = 1;
-            partitionType = "count";
-          });
+
+          rust-docs-mcp-nextest = cranelibNightly.cargoNextest (commonArgs
+            // {
+              inherit cargoArtifacts;
+              partitions = 1;
+              partitionType = "count";
+            });
         };
       };
     };

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/pyfzxz6pp4z73q0j2vfcl2yclz9f8xin-rust-docs-mcp-wrapped

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/pyfzxz6pp4z73q0j2vfcl2yclz9f8xin-rust-docs-mcp-wrapped


### PR DESCRIPTION
This PR fixes the nix flake to use the rust-toolchain.toml file present in the repo root, as well as exposing the same version (since it's nightly) to the resulting binary, which will use it for docs generation.

This should fix issues due to using an incompatible version to build the package as well as allowing users to avoid installing rust nightly directly in their system for doc generation