### PR TITLE
Fix linking in nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
             [
               openssl
               pkg-config
+              gcc.cc.lib
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
               darwin.apple_sdk.frameworks.Security
@@ -64,6 +65,7 @@
 
           nativeBuildInputs = with pkgs; [
             pkg-config
+            autoPatchelfHook
           ];
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -56,17 +56,17 @@
             [
               openssl
               pkg-config
-              gcc.cc.lib
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
               darwin.apple_sdk.frameworks.Security
               darwin.apple_sdk.frameworks.SystemConfiguration
-            ];
+            ]
+            ++ pkgs.lib.optional pkgs.lib.isLinux gcc.cc.lib;
 
           nativeBuildInputs = with pkgs; [
             pkg-config
-            autoPatchelfHook
-          ];
+          ]
+          ++ pkgs.lib.optional pkgs.lib.isLinux autoPatchelfHook;
         };
 
         # Build dependencies only


### PR DESCRIPTION
Adds `autoPatchElfHook`, which corrects binary linking against build inputs.

### Before:

```sh
$ nix build .#
$ ./result/rust-docs-mcp
/nix/store/8x2jh96knxsclgzz7b81q07i3iiaxikj-rust-docs-mcp-0.1.1/bin/rust-docs-mcp: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory)
$ ldd /nix/store/8x2jh96knxsclgzz7b81q07i3iiaxikj-rust-docs-mcp-0.1.1/bin/rust-docs-mcp                                                                                                                              
        linux-vdso.so.1 (0x00007f61b951a000)                                                                                                                                                                         
        libssl.so.3 => not found                                                                                                                                                                                     
        libcrypto.so.3 => not found                                                                                                                                                                                  
        libgcc_s.so.1 => /nix/store/m2047a1xwgblgkrnbxz0yilkaqfrbf2b-xgcc-14-20241116-libgcc/lib/libgcc_s.so.1 (0x00007f61b94e6000)                                                                                  
        libm.so.6 => /nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66/lib/libm.so.6 (0x00007f61b7717000)                                                                                                    
        libc.so.6 => /nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66/lib/libc.so.6 (0x00007f61b7400000)                                                                                                    
        /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007f61b951c000)
```

It appears that the build isn't linking against the build inputs. In nixos the libraries aren't in a standard location, and the resulting binary is unusable.