### PR TITLE
Refactor formatting and improve code style

### DIFF
--- a/rust-docs-mcp/src/doctor.rs
+++ b/rust-docs-mcp/src/doctor.rs
@@ -105,7 +105,7 @@ async fn check_rustdoc_json() -> DiagnosticResult {
                 Ok(_) => DiagnosticResult::new(
                     "Rustdoc JSON".to_string(),
                     true,
-                    format!("{} with JSON support (toolchain: {})", version, toolchain),
+                    format!("{version} with JSON support (toolchain: {toolchain})"),
                     false,
                 ),
                 Err(e) => {

--- a/rust-docs-mcp/src/rustdoc.rs
+++ b/rust-docs-mcp/src/rustdoc.rs
@@ -157,16 +157,13 @@ fn is_missing_toolchain_error(stderr: &str, toolchain: &str) -> bool {
     // Then check it matches our query, allowing for an architecture suffix
     // (e.g., "nightly" -> "nightly-aarch64-apple-darwin") but not a date suffix
     // (e.g., "nightly" should NOT match "nightly-2025-06-24-aarch64-apple-darwin")
-    stderr
-        .split('\'')
-        .nth(1)
-        .is_some_and(|name| {
-            name == toolchain
-                || name
-                    .strip_prefix(toolchain)
-                    .and_then(|rest| rest.strip_prefix('-'))
-                    .is_some_and(|rest| !rest.starts_with(|c: char| c.is_ascii_digit()))
-        })
+    stderr.split('\'').nth(1).is_some_and(|name| {
+        name == toolchain
+            || name
+                .strip_prefix(toolchain)
+                .and_then(|rest| rest.strip_prefix('-'))
+                .is_some_and(|rest| !rest.starts_with(|c: char| c.is_ascii_digit()))
+    })
 }
 
 fn validate_rustdoc_json_format(toolchain: &str) -> Result<()> {


### PR DESCRIPTION
This PR includes minor code style improvements and modernizations across the codebase.

**Key changes:**

- **rustdoc.rs**: Reformatted the `is_missing_toolchain_error` function for improved readability by adjusting indentation of the closure passed to `is_some_and()`. The logic remains unchanged.

- **doctor.rs**: Updated string formatting in the diagnostic message to use modern Rust string interpolation syntax (`{version}` and `{toolchain}`) instead of the older `{}` placeholder style with positional arguments.

These changes improve code consistency and readability without altering any functional behavior.

https://claude.ai/code/session_01NpbtkayRq95kM38aLJu1gd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/snowmead/rust-docs-mcp/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
