### PR TITLE
Fix path handling in tests for Windows compatibility

### DIFF
--- a/rust-docs-mcp/src/cache/downloader.rs
+++ b/rust-docs-mcp/src/cache/downloader.rs
@@ -733,9 +733,15 @@ mod tests {
 
         let cargo_home_dir = TempDir::new().unwrap();
         let storage_dir = TempDir::new().unwrap();
+        // Build the path one component at a time so the separator is
+        // platform-native on Windows (otherwise the embedded `/` ends up
+        // preserved verbatim and breaks string-based path comparisons).
         let cached_source = cargo_home_dir
             .path()
-            .join("registry/src/index.crates.io-test/cached-crate-9.9.9");
+            .join("registry")
+            .join("src")
+            .join("index.crates.io-test")
+            .join("cached-crate-9.9.9");
         fs::create_dir_all(cached_source.join("src")).unwrap();
         fs::write(
             cached_source.join(CARGO_TOML),
@@ -761,15 +767,25 @@ mod tests {
         assert_eq!(found, Some(cached_source));
     }
 
+    // The guard is intentionally held across the `.await` below to serialize
+    // `CARGO_HOME` mutation with the sync test above — no other async task
+    // contends for this lock.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn test_download_crate_reuses_cargo_registry_source() {
         let _guard = cargo_home_lock().lock().unwrap();
 
         let cargo_home_dir = TempDir::new().unwrap();
         let storage_dir = TempDir::new().unwrap();
+        // Build the path one component at a time so the separator is
+        // platform-native on Windows (otherwise the embedded `/` ends up
+        // preserved verbatim and breaks string-based path comparisons).
         let cached_source = cargo_home_dir
             .path()
-            .join("registry/src/index.crates.io-test/cached-crate-9.9.9");
+            .join("registry")
+            .join("src")
+            .join("index.crates.io-test")
+            .join("cached-crate-9.9.9");
         fs::create_dir_all(cached_source.join("src")).unwrap();
         fs::write(
             cached_source.join(CARGO_TOML),


### PR DESCRIPTION
## Summary
Fixed path construction in cache downloader tests to use platform-native path separators on Windows, ensuring string-based path comparisons work correctly across all platforms.

## Key Changes
- **Path construction**: Changed from single `join()` call with embedded `/` separators to multiple `join()` calls, one per path component. This ensures `PathBuf` uses the correct platform-native separator (backslash on Windows, forward slash on Unix).
- **Clippy lint suppression**: Added `#[allow(clippy::await_holding_lock)]` to `test_download_crate_reuses_cargo_registry_source()` with explanatory comment documenting that the lock guard is intentionally held across the `.await` to serialize `CARGO_HOME` mutation with the synchronous test.
- **Documentation**: Added clarifying comments explaining the rationale for the path construction changes.

## Notable Details
The issue occurred because embedding `/` directly in a string passed to `join()` doesn't trigger path normalization—the separator is preserved verbatim. By building paths incrementally with separate `join()` calls, `PathBuf` properly handles platform-specific separators, preventing test failures on Windows due to path comparison mismatches.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/snowmead/rust-docs-mcp/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
