### PR TITLE
chore(ci): fix claude-code-review workflow for @v1 + code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -35,7 +35,15 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # The plugin command only posts comments when invoked with
+          # --comment. Step 7 of the command at
+          # https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md —
+          # "If --comment argument was NOT provided, stop here. Do not
+          # post any GitHub comments." Do NOT add a claude_args
+          # --allowedTools block here — that flag REPLACES the default
+          # tool allowlist and breaks the plugin's subagent launches
+          # (Task), file reads, and internal gh commands.
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

- Bumps `pull-requests` and `issues` from `read` to `write` on the `claude-review` job so the code-review plugin's posting tools can actually call the GitHub API
- Adds `--comment` to the `/code-review:code-review` plugin invocation so the plugin actually posts its review (per step 7 of its command spec)

## Why

### The `@v1` migration in #51 was incomplete

PR #51 migrated the workflow from `anthropics/claude-code-action@beta` to `@v1`, but did not apply the configuration changes that `@v1` + the `code-review` plugin require. The current `main`-branch workflow has never actually run successfully — the only prior "working" run was PR #53, which was branched *before* #51 and still used the old `@beta` + `pull-requests: write` config.

The `@beta` version had a **built-in** PR-review mode that auto-created a sticky comment and used `mcp__github_comment__update_claude_comment`. `@v1` removed that default behavior and now relies on explicit plugins + prompts.

### The two `@v1` requirements

**1. Write scope on `pull-requests` and `issues`.** The plugin declares its own `allowed-tools` in [`commands/code-review.md`](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md):

\`\`\`
allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*),
               Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*),
               Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
\`\`\`

Every one of those posting tools needs `pull-requests: write` (and `issues: write` for the `gh issue`/`gh search` helpers) on the `GITHUB_TOKEN`. Under `read`-only scope, `gh pr comment` and the inline-comment MCP tool silently 403.

**2. `--comment` on the slash command.** Step 7 of the plugin command is explicit:

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

Without it, the plugin analyzes the PR but never posts — it's in "terminal output only" mode.

## Proven out end-to-end

This exact config was verified on [shapes-fyi/shapes#62](https://github.com/shapes-fyi/shapes/pull/62) — the final run of `claude-review` posted the plugin's "No issues found" summary comment via `gh pr comment` as documented, after chasing several red herrings (permission-only fix, over-restrictive `claude_args: --allowedTools`) before finding the actual requirements by reading the plugin source.

## What I deliberately did NOT add

- **No `claude_args: --allowedTools`.** The CLI's `--allowedTools` flag *replaces* the default allowlist rather than adding to it, which breaks the plugin's subagent launches (`Task`), file reads (`Read`, `Grep`), and internal `gh` commands. The plugin already declares its own tools in frontmatter and relies on defaults for the rest; it just needs those tools to have working API scope.

## Test plan

- [ ] After merge: open a new PR authored by `snowmead` and confirm that `claude-review` posts an actual review comment instead of just exiting green silently
- [ ] Note the bootstrap caveat: this PR's own `claude-review` check will likely fail with the `anthropics/claude-code-action` "workflow file must match main" guardrail since the workflow file differs from main. Admin-merge once the other checks are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/snowmead/rust-docs-mcp/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
