### PR TITLE
Test coverage for Cargo registry reuse error and fallback paths

### DIFF
--- a/rust-docs-mcp/src/cache/downloader.rs
+++ b/rust-docs-mcp/src/cache/downloader.rs
@@ -876,4 +876,108 @@ mod tests {
             Some(cached_source.to_string_lossy().to_string())
         );
     }
+
+    #[test]
+    fn test_try_copy_from_cargo_registry_returns_none_when_crate_absent() {
+        let _guard = cargo_home_lock().lock().unwrap();
+
+        let cargo_home_dir = TempDir::new().unwrap();
+        let storage_dir = TempDir::new().unwrap();
+
+        // Registry index directory exists but contains no crate subdirectories.
+        fs::create_dir_all(
+            cargo_home_dir
+                .path()
+                .join("registry")
+                .join("src")
+                .join("index.crates.io-test"),
+        )
+        .unwrap();
+
+        set_cargo_home(cargo_home_dir.path());
+
+        let storage = CacheStorage::new(Some(storage_dir.path().to_path_buf())).unwrap();
+        let downloader = CrateDownloader::new(storage.clone());
+
+        let result = downloader
+            .try_copy_from_cargo_registry("cached-crate", "9.9.9")
+            .unwrap();
+
+        remove_cargo_home();
+
+        assert_eq!(result, None);
+        assert!(
+            !storage
+                .source_path("cached-crate", "9.9.9")
+                .unwrap()
+                .exists()
+        );
+        assert!(
+            !storage
+                .metadata_path("cached-crate", "9.9.9", None)
+                .unwrap()
+                .exists()
+        );
+    }
+
+    #[test]
+    fn test_try_copy_from_cargo_registry_rolls_back_partial_copy() {
+        let _guard = cargo_home_lock().lock().unwrap();
+
+        let cargo_home_dir = TempDir::new().unwrap();
+        let storage_dir = TempDir::new().unwrap();
+
+        // Pre-populate a valid cargo registry source.
+        let cached_source = cargo_home_dir
+            .path()
+            .join("registry")
+            .join("src")
+            .join("index.crates.io-test")
+            .join("cached-crate-9.9.9");
+        fs::create_dir_all(cached_source.join("src")).unwrap();
+        fs::write(
+            cached_source.join(CARGO_TOML),
+            "[package]\nname = \"cached-crate\"\nversion = \"9.9.9\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        fs::write(
+            cached_source.join("src").join("lib.rs"),
+            "pub fn answer() -> u32 { 42 }\n",
+        )
+        .unwrap();
+
+        set_cargo_home(cargo_home_dir.path());
+
+        let storage = CacheStorage::new(Some(storage_dir.path().to_path_buf())).unwrap();
+
+        // Force `copy_directory_contents` to fail mid-walk by planting an empty
+        // directory at the destination path where `src/lib.rs` would be copied.
+        // `fs::copy` opens the destination via `File::create`, which errors out
+        // on a directory (EISDIR on Unix; access-denied on Windows). This
+        // happens after `ensure_dir(&source_path)` succeeds and potentially
+        // after `Cargo.toml` is already copied — so the rollback branch must
+        // clean up genuinely partial state.
+        let source_path = storage.source_path("cached-crate", "9.9.9").unwrap();
+        let planted_lib_rs = source_path.join("src").join("lib.rs");
+        fs::create_dir_all(&planted_lib_rs).unwrap();
+
+        let downloader = CrateDownloader::new(storage.clone());
+
+        let result = downloader.try_copy_from_cargo_registry("cached-crate", "9.9.9");
+
+        remove_cargo_home();
+
+        // We only assert the error shape, never the error text — the underlying
+        // OS error code differs across platforms.
+        assert!(result.is_err(), "expected Err from try_copy, got Ok");
+        assert!(
+            !source_path.exists(),
+            "rollback should have removed the partially-copied source directory"
+        );
+        // Sanity check: the cargo registry source was not touched by the rollback.
+        assert!(
+            cached_source.join("src").join("lib.rs").is_file(),
+            "rollback must not reach outside storage's source_path"
+        );
+    }
 }

--- a/rust-docs-mcp/tests/cargo_registry_reuse.rs
+++ b/rust-docs-mcp/tests/cargo_registry_reuse.rs
@@ -1,0 +1,218 @@
+//! End-to-end test for the Cargo registry source reuse path.
+//!
+//! This file lives in its own integration-test binary (separate from
+//! `tests/integration_tests.rs`) because it mutates the process-global
+//! `CARGO_HOME` env var, which would interfere with the other 22 tests that
+//! rely on the ambient toolchain configuration.
+
+use anyhow::{Context, Result};
+use rmcp::handler::server::wrapper::Parameters;
+use rust_docs_mcp::RustDocsService;
+use rust_docs_mcp::cache::constants::CARGO_TOML;
+use rust_docs_mcp::cache::outputs::CacheTaskStartedOutput;
+use rust_docs_mcp::cache::storage::CacheStorage;
+use rust_docs_mcp::cache::tools::{CacheCrateParams, CacheOperationsParams};
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+use tempfile::TempDir;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Serializes `CARGO_HOME` mutations between tests in this binary. Only tests
+/// in this file contend for this lock; other integration test binaries run in
+/// separate processes and don't touch it.
+fn cargo_home_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// RAII drop guard that removes `CARGO_HOME` when the test ends, so a panic
+/// in the middle of the test doesn't leak env state into later tests if any
+/// are added to this binary.
+struct CargoHomeGuard;
+
+impl Drop for CargoHomeGuard {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::remove_var("CARGO_HOME");
+        }
+    }
+}
+
+fn set_cargo_home(path: &Path) -> CargoHomeGuard {
+    unsafe {
+        std::env::set_var("CARGO_HOME", path);
+    }
+    CargoHomeGuard
+}
+
+// Minimal copies of the helpers in `tests/integration_tests.rs`. Duplicating
+// them here (rather than extracting to a shared module) keeps the scope of
+// this change small — no refactor of the existing test harness.
+fn parse_cache_task_started(response: &str) -> Result<CacheTaskStartedOutput> {
+    serde_json::from_str(response).map_err(|e| {
+        anyhow::anyhow!("Failed to parse task started response: {e}\nResponse: {response}")
+    })
+}
+
+#[derive(Debug)]
+#[allow(dead_code)] // Fields are used for diagnostic output via Debug
+enum TaskTerminal {
+    Success,
+    Failed(String),
+    Other(String),
+}
+
+async fn wait_for_task_terminal(
+    service: &RustDocsService,
+    task_id: &str,
+    timeout: Duration,
+) -> Result<TaskTerminal> {
+    let start = std::time::Instant::now();
+    let poll_interval = Duration::from_millis(500);
+
+    loop {
+        if start.elapsed() > timeout {
+            return Err(anyhow::anyhow!(
+                "Timeout waiting for task {task_id} to reach a terminal state after {timeout:?}"
+            ));
+        }
+
+        let params = CacheOperationsParams {
+            task_id: Some(task_id.to_string()),
+            status_filter: None,
+            cancel: false,
+            clear: false,
+        };
+
+        let response = service.cache_operations(Parameters(params)).await;
+
+        if response.contains("COMPLETED ✓") {
+            return Ok(TaskTerminal::Success);
+        } else if response.contains("FAILED ✗") {
+            return Ok(TaskTerminal::Failed(response));
+        } else if response.contains("CANCELLED") {
+            return Ok(TaskTerminal::Other(response));
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+// `#[tokio::test]` defaults to a `current_thread` runtime, so holding the
+// sync `MutexGuard` across `.await` is safe — only one thread ever runs the
+// future. We hold the guard for the whole test because `CARGO_HOME` is
+// process-global and must not be mutated concurrently.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn test_cache_crate_reuses_cargo_registry_source() -> Result<()> {
+    let _lock = cargo_home_lock().lock().unwrap();
+
+    // Use a UUID-suffixed crate name so the HTTP fallback would 404 against
+    // crates.io if the reuse path silently breaks. A literal name like
+    // "fake-crate" could be squatted in the registry; a UUID cannot.
+    let crate_name = format!("rust-docs-mcp-testonly-{}", uuid::Uuid::new_v4().simple());
+    let crate_version = "0.0.1";
+
+    // Pre-populate a fake cargo registry source layout:
+    //   $CARGO_HOME/registry/src/index.crates.io-test/<crate>-<version>/
+    let cargo_home_dir = TempDir::new()?;
+    let cache_dir = TempDir::new()?;
+
+    let cached_source = cargo_home_dir
+        .path()
+        .join("registry")
+        .join("src")
+        .join("index.crates.io-test")
+        .join(format!("{crate_name}-{crate_version}"));
+    std::fs::create_dir_all(cached_source.join("src"))?;
+    std::fs::write(
+        cached_source.join(CARGO_TOML),
+        format!(
+            "[package]\nname = \"{crate_name}\"\nversion = \"{crate_version}\"\nedition = \"2021\"\n"
+        ),
+    )?;
+    std::fs::write(
+        cached_source.join("src").join("lib.rs"),
+        "pub fn answer() -> u32 { 42 }\n",
+    )?;
+
+    // Install the fake CARGO_HOME. The drop guard removes it on test exit so
+    // a panic here doesn't leak state into other tests added to this binary.
+    let _cargo_home_guard = set_cargo_home(cargo_home_dir.path());
+
+    let service = RustDocsService::new(Some(cache_dir.path().to_path_buf()))?;
+
+    let params = CacheCrateParams {
+        crate_name: crate_name.clone(),
+        source_type: "cratesio".to_string(),
+        version: Some(crate_version.to_string()),
+        github_url: None,
+        branch: None,
+        tag: None,
+        path: None,
+        members: None,
+        update: None,
+    };
+
+    let response = service.cache_crate(Parameters(params)).await;
+    let task_output = parse_cache_task_started(&response)?;
+    assert_eq!(task_output.crate_name, crate_name);
+    assert_eq!(task_output.version, crate_version);
+
+    let terminal = wait_for_task_terminal(&service, &task_output.task_id, TEST_TIMEOUT).await?;
+
+    // Assert the reuse metadata BEFORE asserting the task result. The
+    // metadata is written at downloader.rs::try_copy_from_cargo_registry
+    // *before* `generate_docs` runs nightly rustdoc — so even if rustdoc
+    // fails on the minimal fake lib, the reuse evidence is on disk and is
+    // what we actually want to verify.
+    let storage = CacheStorage::new(Some(cache_dir.path().to_path_buf()))?;
+
+    let metadata = storage
+        .load_metadata(&crate_name, crate_version, None)
+        .with_context(|| {
+            format!(
+                "metadata for {crate_name}-{crate_version} was not written — the reuse path did not run (terminal: {terminal:?})"
+            )
+        })?;
+
+    assert_eq!(
+        metadata.source, "crates.io",
+        "reuse path should record source as crates.io"
+    );
+    let recorded_source_path = metadata
+        .source_path
+        .as_deref()
+        .expect("reuse path should record source_path pointing into CARGO_HOME");
+    assert!(
+        Path::new(recorded_source_path).starts_with(cargo_home_dir.path()),
+        "recorded source_path {recorded_source_path} should live inside the fake CARGO_HOME {}",
+        cargo_home_dir.path().display()
+    );
+
+    let cached_cargo_toml = storage
+        .source_path(&crate_name, crate_version)?
+        .join(CARGO_TOML);
+    assert!(
+        cached_cargo_toml.is_file(),
+        "cached source should contain a Cargo.toml"
+    );
+    let cargo_toml_contents = std::fs::read_to_string(&cached_cargo_toml)?;
+    assert!(
+        cargo_toml_contents.contains(crate_version),
+        "cached Cargo.toml should be our fake manifest (contents: {cargo_toml_contents})"
+    );
+
+    // The task itself may report Success (reuse + rustdoc both worked) or
+    // Failed (reuse worked but rustdoc failed on the minimal fake lib). Both
+    // are acceptable — what we care about is that the reuse metadata is on
+    // disk. A `Cancelled` terminal would indicate something odd, though.
+    match terminal {
+        TaskTerminal::Success | TaskTerminal::Failed(_) => Ok(()),
+        TaskTerminal::Other(msg) => Err(anyhow::anyhow!(
+            "unexpected terminal state (neither success nor failed): {msg}"
+        )),
+    }
+}


### PR DESCRIPTION
## Summary
Fills in the test-coverage gaps exposed by the registry-reuse work in #45. The merged PR only covered the happy path; these tests exercise the `Ok(None)` fall-through, the rollback cleanup after a mid-copy failure, and the end-to-end reuse path through `RustDocsService::cache_crate`.

- **Unit test** — `try_copy_from_cargo_registry` returns `Ok(None)` when `CARGO_HOME` has an empty registry index, and does not pollute storage.
- **Unit test** — rollback cleanup when `copy_directory_contents` fails mid-walk. Forces the failure by planting an empty directory at the destination path where `fs::copy` would write `src/lib.rs`, making `File::create` on the destination fail with EISDIR. Verifies `source_path` is wiped and the cargo registry source is untouched.
- **Integration test** — new binary `rust-docs-mcp/tests/cargo_registry_reuse.rs` that wires a fake `CARGO_HOME` registry source and drives `RustDocsService::cache_crate` end-to-end. Uses a UUID-suffixed crate name so the HTTP fallback would 403 if the reuse path silently breaks, and asserts the reuse metadata *before* checking the task terminal state so the verification doesn't depend on nightly rustdoc succeeding on the minimal fake lib.

The integration test lives in its own test binary (not `tests/integration_tests.rs`) because it mutates the process-global `CARGO_HOME` env var, which would interfere with the 22 existing network-dependent tests.

## Test plan
- [x] `cargo fmt --check -p rust-docs-mcp`
- [x] `cargo clippy -p rust-docs-mcp --all-targets -- -D warnings`
- [x] `cargo test -p rust-docs-mcp --lib cache::downloader::tests::test_try_copy_from_cargo_registry_returns_none_when_crate_absent`
- [x] `cargo test -p rust-docs-mcp --lib cache::downloader::tests::test_try_copy_from_cargo_registry_rolls_back_partial_copy`
- [x] `cargo test -p rust-docs-mcp --test cargo_registry_reuse`
- [x] `cargo test -p rust-docs-mcp --lib cache::` — 38 passing (was 36)
- [x] **Negative assertion check:** temporarily disabled `try_copy_from_cargo_registry` in `download_crate` and confirmed `test_cache_crate_reuses_cargo_registry_source` fails with a clear `metadata for rust-docs-mcp-testonly-...-0.0.1 was not written` diagnostic (crates.io returned HTTP 403 for the UUID name, as expected). Reverted cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/snowmead/rust-docs-mcp/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
